### PR TITLE
Fixed building errors from gcc's typeof and boost's rvalue

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@ ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = . tools/lang src lib
 
 # NOTE: being C++, these only affect build of the tools, not the liballocs core.
-AM_CXXFLAGS = -std=c++11 -ggdb -fkeep-inline-functions -O2 -Wall -Wno-deprecated-declarations -fPIC -Wp,-w -Iinclude $(LIBSRK31CXX_CFLAGS) $(LIBCXXFILENO_CFLAGS) $(LIBDWARFPP_CFLAGS) $(LIBCXXGEN_CFLAGS) $(LIBANTLR3CXX_CFLAGS) $(DWARFIDL_CFLAGS)
+AM_CXXFLAGS = -std=c++11 -ggdb -fkeep-inline-functions -O2 -Wall -Wno-deprecated-declarations -fPIC -Wp,-w -Iinclude $(LIBSRK31CXX_CFLAGS) $(LIBCXXFILENO_CFLAGS) $(LIBDWARFPP_CFLAGS) $(LIBCXXGEN_CFLAGS) $(LIBANTLR3CXX_CFLAGS) $(DWARFIDL_CFLAGS) -DBOOST_OPTIONAL_CONFIG_ALLOW_BINDING_TO_RVALUES
 
 AM_CFLAGS = -Wall -std=gnu99 -ggdb -O3 -flto -Iinclude -fPIC -Wp,-w
 

--- a/tools/dumptypes.cpp
+++ b/tools/dumptypes.cpp
@@ -121,11 +121,11 @@ struct iter_hash
 	
 	struct set : unordered_set<
 		T,
-		std::function<typeof(hash_fn)>,
-		std::function<typeof(eq_fn)>
+		std::function<__typeof__(hash_fn)>,
+		std::function<__typeof__(eq_fn)>
 	>
 	{
-		set() : unordered_set<T, std::function<typeof(hash_fn)>, std::function<typeof(eq_fn)> >({}, 0, hash_fn, eq_fn) {}
+		set() : unordered_set<T, std::function<__typeof__(hash_fn)>, std::function<__typeof__(eq_fn)> >({}, 0, hash_fn, eq_fn) {}
 	};
 };
 
@@ -141,11 +141,11 @@ struct iterfirst_pair_hash
 
 	struct set : unordered_set< 
 		T,
-		std::function<typeof(hash_fn)>,
-		std::function<typeof(eq_fn)>
+		std::function<__typeof__(hash_fn)>,
+		std::function<__typeof__(eq_fn)>
 	>
 	{
-		set() : unordered_set<T, std::function<typeof(hash_fn)>, std::function<typeof(eq_fn)> >
+		set() : unordered_set<T, std::function<__typeof__(hash_fn)>, std::function<__typeof__(eq_fn)> >
 			({}, 0, hash_fn, eq_fn) 
 			{}
 	};
@@ -164,11 +164,11 @@ struct itersecond_pair_hash
 
 	struct set : unordered_set< 
 		T,
-		std::function<typeof(hash_fn)>,
-		std::function<typeof(eq_fn)>
+		std::function<__typeof__(hash_fn)>,
+		std::function<__typeof__(eq_fn)>
 	>
 	{
-		set() : unordered_set<T, std::function<typeof(hash_fn)>, std::function<typeof(eq_fn)> >
+		set() : unordered_set<T, std::function<__typeof__(hash_fn)>, std::function<__typeof__(eq_fn)> >
 			({}, 0, hash_fn, eq_fn) 
 			{}
 	};
@@ -197,7 +197,7 @@ struct hash<dwarf::encap::loc_expr>
 		size_t working = 0;
 		for (auto i = v.begin(); i != v.end(); ++i)
 		{
-			working ^= std::hash<typeof(*i)>()(*i);
+			working ^= std::hash<__typeof__(*i)>()(*i);
 		}
 		return working;
 	}


### PR DESCRIPTION
1.  Ran into the boost error `binding rvalue references to optional lvalue references is disallowed`. This can be fixed by adding the `-DBOOST_OPTIONAL_CONFIG_ALLOW_BINDING_TO_RVALUES` flag.
2. Using gcc with `-std=c++11` means `__typeof__` must be used, not `typeof`. dumptypes.cpp was the only file that had `typeof` left in it, so I've changed all occurrences in there.
 