### PR TITLE
Remove LLVM submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,11 +25,3 @@
 [submodule "contrib/libdlbind"]
 	path = contrib/libdlbind
 	url = git://github.com/stephenrkell/libdlbind.git
-[submodule "contrib/llvm"]
-	path = contrib/llvm
-	url = git://github.com/stephenrkell/llvm.git
-	active = false
-[submodule "contrib/llvm/tools/clang"]
-	path = contrib/llvm/tools/clang
-	url = git://github.com/stephenrkell/clang.git
-	active = false

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -191,6 +191,9 @@ CONFIG_MK += \nLIBDLBIND ?= $(CONTRIB_ROOT)/libdlbind\n
 CONFIG_MK += \nMALLOC_HOOKS := $(CONTRIB_ROOT)/libmallochooks\n
 
 # ----------------------------optional: LLVM (Chris Diamand's fork, for now)
+# Currently not usable, work needed to revive. To test, check out:
+#   * https://github.com/stephenrkell/llvm to contrib/llvm
+#   * https://github.com/stephenrkell/clang to contrib/llvm/tools/clang
 .PHONY: llvm llvm-build
 llvm: llvm/build/LLVMBuild.cmake llvm-build
 


### PR DESCRIPTION
Git seems very perplexed about these submodules, possibly because
Clang's path is nested within LLVM's path, even though they are both
configured in this top level modules file.

For some reason, it seems to insist on pulling in the Clang module but
not the LLVM one, even though they are both inactive.

Since it doesn't work at the moment, let's simplify by removing and
adding a note about it for possible future restoration.