### PR TITLE
Tune dependencies to ease getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,10 +210,10 @@ Generic download-and-build instructions for Debian platforms
 look something like the following.
 
     $ # step 0: FIRST optionally build my binutils-gdb repo (see below)
-    $ sudo apt-get install libelfg0-dev libdw-dev binutils-dev \
+    $ sudo apt-get install libelf-dev libdw-dev binutils-dev \
         autoconf automake libtool pkg-config autoconf-archive \
-        g++ ocaml ocaml-findlib \
-        default-jre-headless \
+        g++ ocaml ocamlbuild ocaml-findlib \
+        default-jre-headless python3 python \
         make git gawk gdb wget \
         libunwind-dev libc6-dev-i386 zlib1g-dev libc6-dbg \
         libboost-{iostreams,regex,serialization,filesystem}-dev && \

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Generic download-and-build instructions for Debian platforms
 look something like the following.
 
     $ # step 0: FIRST optionally build my binutils-gdb repo (see below)
-    $ sudo apt-get install libelfg0-dev libdw-dev \
+    $ sudo apt-get install libelfg0-dev libdw-dev binutils-dev \
         autoconf automake libtool pkg-config autoconf-archive \
         g++ ocaml ocaml-findlib \
         default-jre-headless \

--- a/buildtest/debian-buster/Dockerfile
+++ b/buildtest/debian-buster/Dockerfile
@@ -18,7 +18,7 @@ RUN cd /usr/local/src/binutils-gdb && \
 RUN cd /usr/local/bin && sudo rm -f ld && sudo ln -s ld.bfd ld
 RUN sudo mkdir -p /usr/lib/meta && sudo chown root:staff /usr/lib/meta && \
    sudo chmod g+w /usr/lib/meta
-RUN sudo apt-get install -y libelf-dev libdw-dev \
+RUN sudo apt-get install -y libelf-dev libdw-dev binutils-dev \
        autoconf automake libtool pkg-config autoconf-archive \
        g++ ocaml ocaml-findlib \
        default-jre-headless python3 python2.7 python-minimal \

--- a/buildtest/debian-buster/Dockerfile
+++ b/buildtest/debian-buster/Dockerfile
@@ -20,9 +20,9 @@ RUN sudo mkdir -p /usr/lib/meta && sudo chown root:staff /usr/lib/meta && \
    sudo chmod g+w /usr/lib/meta
 RUN sudo apt-get install -y libelf-dev libdw-dev binutils-dev \
        autoconf automake libtool pkg-config autoconf-archive \
-       g++ ocaml ocaml-findlib \
-       default-jre-headless python3 python2.7 python-minimal \
-       make git gawk gdb nano wget \
+       g++ ocaml ocamlbuild ocaml-findlib \
+       default-jre-headless python3 python \
+       make git gawk gdb wget \
        libunwind-dev libc6-dev-i386 zlib1g-dev libc6-dbg \
        libboost-iostreams-dev libboost-regex-dev libboost-serialization-dev libboost-filesystem-dev
 RUN cd /usr/local/src && git clone https://github.com/stephenrkell/liballocs.git

--- a/buildtest/debian-stretch/Dockerfile
+++ b/buildtest/debian-stretch/Dockerfile
@@ -21,8 +21,8 @@ RUN sudo mkdir -p /usr/lib/meta && sudo chown root:staff /usr/lib/meta && \
 RUN sudo apt-get install -y libelf-dev libdw-dev binutils-dev \
        autoconf automake libtool pkg-config autoconf-archive \
        g++ ocaml ocaml-findlib \
-       default-jre-headless python3 python2.7 python-minimal \
-       make git gawk gdb nano wget \
+       default-jre-headless python3 python \
+       make git gawk gdb wget \
        libunwind-dev libc6-dev-i386 zlib1g-dev libc6-dbg \
        libboost-iostreams-dev libboost-regex-dev libboost-serialization-dev libboost-filesystem-dev
 RUN cd /usr/local/src && git clone https://github.com/stephenrkell/liballocs.git

--- a/buildtest/debian-stretch/Dockerfile
+++ b/buildtest/debian-stretch/Dockerfile
@@ -18,7 +18,7 @@ RUN cd /usr/local/src/binutils-gdb && \
 RUN cd /usr/local/bin && sudo rm -f ld && sudo ln -s ld.bfd ld
 RUN sudo mkdir -p /usr/lib/meta && sudo chown root:staff /usr/lib/meta && \
    sudo chmod g+w /usr/lib/meta
-RUN sudo apt-get install -y libelf-dev libdw-dev \
+RUN sudo apt-get install -y libelf-dev libdw-dev binutils-dev \
        autoconf automake libtool pkg-config autoconf-archive \
        g++ ocaml ocaml-findlib \
        default-jre-headless python3 python2.7 python-minimal \

--- a/buildtest/ubuntu-18.04/Dockerfile
+++ b/buildtest/ubuntu-18.04/Dockerfile
@@ -18,7 +18,7 @@ RUN cd /usr/local/src/binutils-gdb && \
 RUN cd /usr/local/bin && sudo rm -f ld && sudo ln -s ld.bfd ld
 RUN sudo mkdir -p /usr/lib/meta && sudo chown root:staff /usr/lib/meta && \
    sudo chmod g+w /usr/lib/meta
-RUN sudo apt-get install -y libelf-dev libdw-dev \
+RUN sudo apt-get install -y libelf-dev libdw-dev binutils-dev \
        autoconf automake libtool pkg-config autoconf-archive \
        g++ ocaml ocamlbuild ocaml-findlib \
        default-jre-headless python3 python2.7 python-minimal \

--- a/buildtest/ubuntu-18.04/Dockerfile
+++ b/buildtest/ubuntu-18.04/Dockerfile
@@ -21,8 +21,8 @@ RUN sudo mkdir -p /usr/lib/meta && sudo chown root:staff /usr/lib/meta && \
 RUN sudo apt-get install -y libelf-dev libdw-dev binutils-dev \
        autoconf automake libtool pkg-config autoconf-archive \
        g++ ocaml ocamlbuild ocaml-findlib \
-       default-jre-headless python3 python2.7 python-minimal \
-       make git gawk gdb nano wget \
+       default-jre-headless python3 python \
+       make git gawk gdb wget \
        libunwind-dev libc6-dev-i386 zlib1g-dev libc6-dbg \
        libboost-iostreams-dev libboost-regex-dev libboost-serialization-dev libboost-filesystem-dev
 RUN cd /usr/local/src && git clone https://github.com/stephenrkell/liballocs.git

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,7 @@ AC_CHECK_HEADERS([sys/mman.h sys/resource.h sys/stat.h sys/syscall.h sys/time.h 
 AC_CHECK_HEADERS([alloca.h], [], [AC_MSG_FAILURE(Failed to find required header)])
 AC_CHECK_HEADERS([libelf.h libelf/libelf.h gelf.h libelf/gelf.h], [], [], [])
 AC_CHECK_HEADERS([dwarf.h], [], [AC_MSG_FAILURE(Failed to find required header)])
+AC_CHECK_HEADERS([plugin-api.h], [], [AC_MSG_FAILURE([Failed to find required header, try installing `binutils-dev` or a similar package])])
 
 AX_BOOST_BASE
 


### PR DESCRIPTION
This tunes the dependencies in the README and Dockerfiles in several ways:

* Adds `binutils-dev` needed by `gold-plugin.cpp`
* Standardises the dependency lists to be more aligned