### PR TITLE
Fix offsetof parse error in CIL inlines

### DIFF
--- a/include/liballocs_cil_inlines.h
+++ b/include/liballocs_cil_inlines.h
@@ -20,6 +20,10 @@
 //#define assert(cond)
 //#endif
 #endif
+#ifndef offsetof
+#define __liballocs_defined_offsetof
+#define offsetof(type, member) (__builtin_offsetof(type, member))
+#endif
 
 /* Prototypes we omit. */
 void abort(void) __attribute__((noreturn));


### PR DESCRIPTION
This fixes a regression introduced by the recent lifetime merge
(at commit 80a6dd03a83e128dc8e49129adad8cb76bf82662). It makes use of
`ALLOCA_ALIGN` which may in turn call `offsetof`, but we might not have
`stddef.h` included, so it can cause `cilly` to return a parse error
when running the tests.

For example, I was seeing the following:

```
(at liballocs root) $ make -C tests -j 1
make: Entering directory '/home/jryans/Projects/liballocs/tests'
expected-fail case is abort-alloca-clang
out is /tmp/tmp.OfZuWQaSQS
err is /tmp/tmp.zW8hcsfgiv
case is addrtaken-allocator
out is /tmp/tmp.SVG6Niei1S
err is /tmp/tmp.fJaWAd2Saa
/home/jryans/Projects/liballocs/tools/lang/c/bin/../../../../include/liballocs_cil_inlines.h[116:70-78] : syntax error
Parsing errorFatal error: exception Frontc.ParseError("Parse error")
make[4]: *** [addrtaken-allocator] Error 2
make[3]: *** [build-addrtaken-allocator] Error 2
make[2]: *** [run-addrtaken-allocator] Error 2
make[1]: *** [cleanrun-addrtaken-allocator] Error 2
Makefile:84: recipe for target 'checkrun-addrtaken-allocator' failed
make: *** [checkrun-addrtaken-allocator] Error 1
make: Leaving directory '/home/jryans/Projects/liballocs/tests'
```