### PR TITLE
buildtest/debian-buster/Dockerfile: Add missing python3-distutils

### DIFF
--- a/buildtest/debian-buster/Dockerfile
+++ b/buildtest/debian-buster/Dockerfile
@@ -21,7 +21,7 @@ RUN sudo mkdir -p /usr/lib/meta && sudo chown root:staff /usr/lib/meta && \
 RUN sudo apt-get install -y libelf-dev libdw-dev binutils-dev \
        autoconf automake libtool pkg-config autoconf-archive \
        g++ ocaml ocamlbuild ocaml-findlib \
-       default-jre-headless python3 python \
+       default-jre-headless python3 python3-distutils python \
        make git gawk gdb wget \
        libunwind-dev libc6-dev-i386 zlib1g-dev libc6-dbg \
        libboost-iostreams-dev libboost-regex-dev libboost-serialization-dev libboost-filesystem-dev


### PR DESCRIPTION
Required by allocscompilerwrapper.py, otherwise it fails will `no such module distutils.spawn` or something like that (I didn't save the error message).

Note that the resulting executables still don't work fully, eg the sample `test.c` in README.md is broken, produces:

```
$ LD_PRELOAD=/usr/local/src/liballocs/lib/liballocs_preload.so ./test
xed could not decode instruction at 0x0000557aa6486a2a
xed could not decode instruction at 0x00007f3aeb0da64a
xed could not decode instruction at 0x00007f3aeb122c36
xed could not decode instruction at 0x00007f3aeb54ae7e
xed could not decode instruction at 0x00007f3aeb557a4e
test: Warning: mapping of (null) could not extend preceding bigalloc
At 0x557aa64868c5 is a static-allocated object of size 0, type __FUN_FROM___ARG0_int$32__ARG1___PTR___PTR_signed_char$8__FUN_TO_int$32
```

and just hangs there with 100% CPU usage and requires SIGKILL to kill it. I did check which of the queries is actually failing, so anything in static storage is fine (functions & static/global variables); stack & heap allocations hang. I would presume at this stage that the problem are the `xed could not decode instruction` messages, but I haven't quite wrapped my head around how the `xed` fits alongside the rest of liballocs.

The annoying part from my POV is that building the debian-stretch Dockerfile on my buster systems is broken as `struct ucontext` & `ucontext_t` have changed between the two releases and therefore I can't just use the stretch docker build.  I ran into this problem with yocto before in a professional capacity, and me couldn't find a workaround back then.