### PR TITLE
Added jdk dependency and removed meta.c build that is no longer needed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/stephenrkell/libmallochooks
 [submodule "tools/lang/c/cil"]
 	path = tools/lang/c/cil
-	url = git://github.com/stephenrkell/cil.git
+	url = git://github.com/chrisbaish/cil.git
 [submodule "contrib/libdlbind"]
 	path = contrib/libdlbind
 	url = git://github.com/stephenrkell/libdlbind.git

--- a/buildtest/ubuntu-18.04/Dockerfile
+++ b/buildtest/ubuntu-18.04/Dockerfile
@@ -21,7 +21,7 @@ RUN sudo mkdir -p /usr/lib/meta && sudo chown root:staff /usr/lib/meta && \
 RUN sudo apt-get install -y libelf-dev libdw-dev binutils-dev \
        autoconf automake libtool pkg-config autoconf-archive \
        g++ ocaml ocamlbuild ocaml-findlib \
-       default-jre-headless python3 python \
+       default-jre-headless default-jdk-headless python3 python \
        make git gawk gdb wget \
        libunwind-dev libc6-dev-i386 zlib1g-dev libc6-dbg \
        libboost-iostreams-dev libboost-regex-dev libboost-serialization-dev libboost-filesystem-dev
@@ -35,7 +35,5 @@ RUN cd /usr/local/src/liballocs && \
    make -j4
 RUN sudo mkdir -p /usr/lib/meta && sudo chown root:user /usr/lib/meta && \
    sudo chmod g+w /usr/lib/meta
-RUN cd /usr/local/src/liballocs && \
-   make -f tools/Makefile.meta /usr/lib/meta/lib/x86_64-linux-gnu/libc-2.27.so-meta.c
 RUN cd /usr/local/src/liballocs && \
    make -f tools/Makefile.meta /usr/lib/meta/lib/x86_64-linux-gnu/libc-2.27.so-meta.so


### PR DESCRIPTION
Added default-jdk-headless to dependencies to fix missing requirement for javac.

Removed build of libc-2.27.so-meta.c which is no longer required.