### PR TITLE
chore: Bot to make "Update submodule x" pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This will check daily whether there are any updates to submodules and automatically make a PR if so, might be handy if dependencies such as CIL or libsystrap get updated.

It doesn't work recursively, but if this is something we want, I think other packages down the tree might benefit from this as well.


