### PR TITLE
Skip liballocs-related preprocessing changes if `-E` seen

### DIFF
--- a/tools/allocscompilerwrapper.py
+++ b/tools/allocscompilerwrapper.py
@@ -581,6 +581,9 @@ class AllocsCompilerWrapper(CompilerWrapper):
            del os.environ["CC"]
         self.debugMsg(sys.argv[0] + " called with args  " + " ".join(sys.argv) + "\n")
 
+        if self.onlyPreprocessing:
+            self.debugMsg("We are only preprocessing, so we won't do anything liballocs-related.")
+
         if Phase.LINK in self.enabledPhases:
             self.debugMsg("We are a link command\n")
         else:

--- a/tools/allocscompilerwrapper.py
+++ b/tools/allocscompilerwrapper.py
@@ -581,7 +581,7 @@ class AllocsCompilerWrapper(CompilerWrapper):
            del os.environ["CC"]
         self.debugMsg(sys.argv[0] + " called with args  " + " ".join(sys.argv) + "\n")
 
-        if self.onlyPreprocessing:
+        if self.onlyPreprocessing():
             self.debugMsg("We are only preprocessing, so we won't do anything liballocs-related.")
 
         if Phase.LINK in self.enabledPhases:

--- a/tools/compilerwrapper.py
+++ b/tools/compilerwrapper.py
@@ -183,6 +183,9 @@ class CompilerWrapper:
 
     # the phase options themselves
     phaseOptions = [dict({}) for n in range(Phase.DRIVER, 1+Phase.LINK)]
+
+    # tracks whether we're only preprocessing, i.e. whether -E was passed.
+    onlyPreprocessing = False
     
     # What do we do with '--' or equivalents?
     # It *is* still necessary, and part of "items", because some "options" are actually "options"
@@ -317,6 +320,7 @@ class CompilerWrapper:
             elif args[num] == '-E':
                 self.argItem({Phase.DRIVER}, num)
                 self.enabledPhases = {Phase.PREPROCESS}
+                self.onlyPreprocessing = True
             elif args[num] == '-S':
                 self.argItem({Phase.DRIVER}, num)
                 self.enabledPhases = {Phase.PREPROCESS, Phase.COMPILE}

--- a/tools/compilerwrapper.py
+++ b/tools/compilerwrapper.py
@@ -184,8 +184,9 @@ class CompilerWrapper:
     # the phase options themselves
     phaseOptions = [dict({}) for n in range(Phase.DRIVER, 1+Phase.LINK)]
 
-    # tracks whether we're only preprocessing, i.e. whether -E was passed.
-    onlyPreprocessing = False
+    # Report whether we're doing anything other than preprocessing
+    def onlyPreprocessing(self):
+        return self.enabledPhases == {Phase.PREPROCESS}
     
     # What do we do with '--' or equivalents?
     # It *is* still necessary, and part of "items", because some "options" are actually "options"
@@ -320,7 +321,6 @@ class CompilerWrapper:
             elif args[num] == '-E':
                 self.argItem({Phase.DRIVER}, num)
                 self.enabledPhases = {Phase.PREPROCESS}
-                self.onlyPreprocessing = True
             elif args[num] == '-S':
                 self.argItem({Phase.DRIVER}, num)
                 self.enabledPhases = {Phase.PREPROCESS, Phase.COMPILE}

--- a/tools/lang/c/bin/allocscc
+++ b/tools/lang/c/bin/allocscc
@@ -38,7 +38,7 @@ class AllocsCC(AllocsCompilerWrapper):
         return ["free(P)"]
 
     def getCustomCompileArgs(self):
-        if self.onlyPreprocessing:
+        if self.onlyPreprocessing():
             return []
         # "-pipe" interferes with -save-temps, with disastrous conseqeunces
         # trying to create files named "-.i", "-.s" which then get interpreted
@@ -76,7 +76,7 @@ class AllocsCC(AllocsCompilerWrapper):
     def getIncludeArgs(self, sourceFiles):
         return ["-include", \
                REAL_DIR + "/../../../../include/liballocs_cil_inlines.h"] \
-               if len(sourceFiles) > 0 and self.areAllSourceFilesC(sourceFiles) and not self.onlyPreprocessing else []
+               if len(sourceFiles) > 0 and self.areAllSourceFilesC(sourceFiles) and not self.onlyPreprocessing() else []
 
     def getCillyArgs(self, sourceFiles):
         allSourceFilesAreC = self.areAllSourceFilesC(sourceFiles)
@@ -91,7 +91,7 @@ class AllocsCC(AllocsCompilerWrapper):
 
         # If we're only preprocessing (i.e. if -E is passed) we bypass cilly
         # So, cilly arguments shouldn't be added...!
-        if self.onlyPreprocessing:
+        if self.onlyPreprocessing():
             return []
         return [
             "--save-temps",
@@ -113,7 +113,7 @@ class AllocsCC(AllocsCompilerWrapper):
         # silence them.
 
     def getBasicCompilerCommand(self):
-        if self.onlyPreprocessing:
+        if self.onlyPreprocessing():
             # TW: This should probably error if ALLOCSCC_CC isn't in environ, but for now...
             if "ALLOCSCC_CC" in os.environ:
                 return [os.environ["ALLOCSCC_CC"]]

--- a/tools/lang/c/bin/allocscc
+++ b/tools/lang/c/bin/allocscc
@@ -117,8 +117,6 @@ class AllocsCC(AllocsCompilerWrapper):
             # TW: This should probably error if ALLOCSCC_CC isn't in environ, but for now...
             if "ALLOCSCC_CC" in os.environ:
                 return [os.environ["ALLOCSCC_CC"]]
-            if "CC" in os.environ:
-                return [os.environ["CC"]]
             return ["cc"]
 
         return [cilly_cmd] + \

--- a/tools/lang/c/bin/allocscc
+++ b/tools/lang/c/bin/allocscc
@@ -38,6 +38,8 @@ class AllocsCC(AllocsCompilerWrapper):
         return ["free(P)"]
 
     def getCustomCompileArgs(self):
+        if self.onlyPreprocessing:
+            return []
         # "-pipe" interferes with -save-temps, with disastrous conseqeunces
         # trying to create files named "-.i", "-.s" which then get interpreted
         # as command-line options.
@@ -74,7 +76,7 @@ class AllocsCC(AllocsCompilerWrapper):
     def getIncludeArgs(self, sourceFiles):
         return ["-include", \
                REAL_DIR + "/../../../../include/liballocs_cil_inlines.h"] \
-               if len(sourceFiles) > 0 and self.areAllSourceFilesC(sourceFiles) else []
+               if len(sourceFiles) > 0 and self.areAllSourceFilesC(sourceFiles) and not self.onlyPreprocessing else []
 
     def getCillyArgs(self, sourceFiles):
         allSourceFilesAreC = self.areAllSourceFilesC(sourceFiles)
@@ -86,6 +88,11 @@ class AllocsCC(AllocsCompilerWrapper):
         # Should fix this.
         #"--load=%s" % (self.getLibAllocsBaseDir() + "tools/lang/c/dumpmemacc/dumpmemacc.cmxs"), \
         #   "--dodumpmemacc", \
+
+        # If we're only preprocessing (i.e. if -E is passed) we bypass cilly
+        # So, cilly arguments shouldn't be added...!
+        if self.onlyPreprocessing:
+            return []
         return [
             "--save-temps",
             "--decil",
@@ -106,6 +113,14 @@ class AllocsCC(AllocsCompilerWrapper):
         # silence them.
 
     def getBasicCompilerCommand(self):
+        if self.onlyPreprocessing:
+            # TW: This should probably error if ALLOCSCC_CC isn't in environ, but for now...
+            if "ALLOCSCC_CC" in os.environ:
+                return [os.environ["ALLOCSCC_CC"]]
+            if "CC" in os.environ:
+                return [os.environ["CC"]]
+            return ["cc"]
+
         return [cilly_cmd] + \
            (["--gcc=%s" % os.environ["ALLOCSCC_CC"]] if "ALLOCSCC_CC" in os.environ else [])
 


### PR DESCRIPTION
When compiling `gnutls` we saw the configure script use the preprocessor to determine flags to pass to the compiler. It did this by preprocessing a list of prospective args to `$CC`, and using the preprocessor to determine which of those were valid. It takes the output from the preprocessor --- a list of "valid" flags to `$CC` --- and supplies that to future calls to `$CC`.

Because `allocscc` injects liballocs-related machinery into the code it compiles, the output of `allocscc`'s preprocessor contains liballocs-related C code. However, `gnutls` uses the preprocessor on something that isn't really C code! When the list of arguments was passed to later calls to `$CC`, the C code injected by `allocscc` would gum up the works.

#118 tracks this.

This PR disables any liballocs-related work if we see `-E` in allocscc's arguments.