### PR TITLE
Remove unused cilly arguments

### DIFF
--- a/tools/lang/c/bin/allocscc
+++ b/tools/lang/c/bin/allocscc
@@ -104,9 +104,7 @@ class AllocsCC(AllocsCompilerWrapper):
             "--load=%s" % (self.getLibAllocsBaseDir() + "/tools/lang/c/monalloca/monalloca.cmxs")] + \
             (["--domonalloca"]
                 if len(sourceFiles) > 0 and allSourceFilesAreC else []) + \
-            ["-Wno-unused-variable", "-Wno-unused-label",
-            "--load=%s" % (self.getLibAllocsBaseDir() + "/tools/lang/c/trapptrwrites/trapptrwrites.cmxs"),
-            "--dotrap-ptr-writes"]
+            ["-Wno-unused-variable", "-Wno-unused-label"]
         # We need the above -Wno-unused-... because CIL creates
         # some unused stuff (unavoidably, I believe) which will
         # make compilation done with -Werror barf if we don't


### PR DESCRIPTION
Contributed by @stephenrkell.

We found that compiling some projects produced errors linking to `__notify_ptr_write`. However, it shouldn't be used anymore!

This commit removes the arguments to cilly that were causing us to try to trap ptr writes.