### PR TITLE
Preserve ordering for `-mllvm <arg>`

### DIFF
--- a/tools/compilerwrapper.py
+++ b/tools/compilerwrapper.py
@@ -371,6 +371,10 @@ class CompilerWrapper:
             elif args[num].startswith("-Xassembler"):
                 self.argOption({Phase.ASSEMBLE}, num, "-Wa," + args[num+1], None)
                 skipNext = True
+            elif args[num].startswith("-mllvm"):
+                if "=" not in args[num]:  # Val can be separated by either a space or '='.
+                    skipNext = True
+                self.argOption({Phase.LINK, Phase.PREPROCESS, Phase.COMPILE, Phase.ASSEMBLE}, num, argToAdd, None if "=" in args[num] else args[num+1])
             elif args[num].startswith('-'):
                 # looks like an option; pass it to all phases
                 self.debugMsg("Default treatment for options %s\n" % args[num])


### PR DESCRIPTION
We had a report from Marc at Galois that the ordering of arguments got tripped when e.g. `-mllvm --blarg` is passed through the compiler wrapper.

This change ensures the ordering of flag and argument is preserved.

However, there's a general case of this: we don't know which `-m`, `-f` etc args work like flags and which ones accept values so it'll continue to pop up until we ensure we always preserve the ordering. I _think_ the ordering is usually preserved and the compiler wrapper is getting tripped up in the case of `-mllvm` because it takes another flag as a value (i.e. `--blarg` instead of `blarg`). I'm unsure. If that _is_ what's tripping it up, it should be a rare case, so this fix should suffice for now.