### PR TITLE
fix: allocsld compilation errors on GCC >=13

### DIFF
--- a/allocsld/allocinstr.c
+++ b/allocsld/allocinstr.c
@@ -217,10 +217,10 @@ _Bool walk_all_ld_so_symbols(struct link_map *ld_so_link_map, void *arg)
 	 * fake up the allocs_file_metadata structure. */
 	struct allocs_file_metadata fake_meta;
 	bzero(&fake_meta, sizeof fake_meta);
-	//int allocsld_find_and_open_meta_libfile(struct allocs_file_metadata *meta);
+	int find_and_open_meta_libfile(struct allocs_file_metadata *meta);
 	fake_meta.m.l = ld_so_link_map;
 	fake_meta.m.filename = fake_meta.m.l->l_name;
-	int fd_meta = /*allocsld_*/find_and_open_meta_libfile(&fake_meta);
+	int fd_meta = find_and_open_meta_libfile(&fake_meta);
 	if (fd_meta == -1) goto out_notloaded;
 	struct loadee_info ld_so_meta = load_from_fd(fd_meta, "metadata object for " SYSTEM_LDSO_PATH,
 		/* loadee_base_addr_hint */ (uintptr_t) 0, NULL, NULL);

--- a/allocsld/chain.c
+++ b/allocsld/chain.c
@@ -9,6 +9,7 @@
 #include "donald.h"
 #include <link.h>
 #include "relf.h"
+#include "cover-tracks.h"
 
 #define die(s, ...) do { fprintf(stderr, DONALD_NAME ": " s , ##__VA_ARGS__); exit(-1); } while(0)
 // #define die(s, ...) do { fwrite(DONALD_NAME ": " s , sizeof DONALD_NAME ": " s, 1, stderr); exit(-1); } while(0)


### PR DESCRIPTION
Hi,

This PR implements two fixes:

- It adds a missing include
- It fixed find_and_open_meta_libfile not being declared. This, however, might be intentional. See below


"We also use one liballocs routine, which we rename
	 * to avoid conflicting with the "main" copy once allocsld and
	 * liballocs_preload are unified into the same library."

Currently, the function used is never declared. Implicit declarations are no longer a warning, but an error. 
CI builds, but I'm not quite sure whether the intention of the original is preserved. Could you please sanity check this? 

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91092

