### PR TITLE
Rework: generic_small allocator

### DIFF
--- a/src/allocators/generic_small.c
+++ b/src/allocators/generic_small.c
@@ -14,6 +14,51 @@
 #include "maps.h"
 #include "liballocs_private.h"
 
+
+struct entry {
+	union {
+		struct {
+			unsigned long discr:48; /* zero? null; small? continuation; non-small lower-half? regular_initial; non-small upper-half? regular with type */
+			unsigned bucket_offset:8; /* offset into the bucket of obj start (zero for continuations) */
+			unsigned thisbucket_size:8;
+		} common;
+		struct{
+			unsigned long alloc_site:47; /* never zero, never small */
+			unsigned always_zero:1;
+			unsigned bucket_offset:8;         /* obj start displacement from bucket start; may be zero */
+			unsigned thisbucket_size:8;
+		} regular_initial;
+		struct{
+			/* XXX: beware: we assume bitfields are allocated from least
+			 * significant to most significant. This is required by the
+			 * System V x86_64 ABI but others may vary. */
+			unsigned alloc_site_id:16;
+			unsigned long uniqtype_dso_idx:9;   // maximum 512 uniqtype-carrying DSOs... hmm
+			unsigned long uniqtype_sym_idx:18;  // maximum 256K dynsyms... hmm
+			unsigned lifetime_policies:4; /* may be zero */
+			unsigned always_one:1;
+			/* The above fields constitute a 48-bit unsigned integer whose value is always
+			 * in the top half of the range, because of the always_one MSB. */
+			unsigned bucket_offset:8; /* may be zero */
+			unsigned thisbucket_size:8;
+		} regular_with_type;
+		struct{
+			unsigned long size:22; /* largest object is 4MB */ /* FIXME: define and use LOG_MINIMUM_USER_ADDRESS */
+			unsigned long always_zero:26; /* ensure our 48-bit value is < MINIMUM_USER_ADDRESS */
+			unsigned unused:8; /* continuations always *start* at offset zero */
+			unsigned thisbucket_size:8;
+		} continuation;
+	};
+} __attribute((packed));
+
+
+#define ENTRY_IS_CONTINUATION(entry) \
+	((entry)->common.discr != 0 && (entry)->common.discr < MINIMUM_USER_ADDRESS)
+
+#define ENTRY_IS_NULL(entry) ((entry)->common.discr == 0)
+#define ENTRY_GET_STORED_OFFSET(entry) ((entry)->common.bucket_offset)
+#define ENTRY_GET_THISBUCKET_SIZE(entry) ((entry)->common.thisbucket_size)
+
 #ifndef NO_PTHREADS
 #define THE_MUTEX &mutex
 /* We're recursive only because assertion failures sometimes want to do 
@@ -40,7 +85,7 @@ static pthread_mutex_t mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 /* The info that describes the whole arena that we're allocating out of. */
 struct chunk_rec
 {
-	struct insert *metadata_recs;
+	struct entry *metadata_recs;
 	unsigned long *starts_bitmap;
 	size_t power_of_two_size;
 	char log_pitch;
@@ -84,7 +129,7 @@ uintptr_t memrect_nbucket_of(void *addr, void *table_coverage_start_addr, unsign
 }
 
 static inline
-uintptr_t memrect_modulus_of_addr(void *addr, void *table_coverage_start_addr, unsigned char log_bucket_pitch)
+uintptr_t memrect_bucket_offset_of_addr(void *addr, void *table_coverage_start_addr, unsigned char log_bucket_pitch)
 {
 	return ((uintptr_t) addr - (uintptr_t) table_coverage_start_addr) % (1ul<<log_bucket_pitch);
 }
@@ -110,43 +155,34 @@ memrect_bucket_range_base(void *bucket, void *rect_base, void *table_coverage_st
 	 (p_chunk_rec)->log_pitch))
 #define NLAYERS(p_chunk_rec) (1ul<<(p_chunk_rec)->log_pitch)
 
-#define LOG_INSERT_SIZE 3 /* insert size is 8 */
+#define LOG_ENTRY_SIZE 3 /* entry size is 8; FIXME: static-assert 1<<this equals sizeof (struct entry) */
 
 #define BUCKET_RANGE_BASE(p_bucket, p_chunk_rec, coverage_start) \
 	(memrect_bucket_range_base((p_bucket), (p_chunk_rec)->metadata_recs, \
-		(coverage_start), (p_chunk_rec)->log_pitch, LOG_INSERT_SIZE))
+		(coverage_start), (p_chunk_rec)->log_pitch, LOG_ENTRY_SIZE))
     
 #define BUCKET_RANGE_END(p_bucket, p_chunk_rec, coverage_start) \
     (((char*)BUCKET_RANGE_BASE((p_bucket), (p_chunk_rec), (coverage_start))) + (1u<<(p_chunk_rec)->log_pitch))
-#define BUCKET_PTR_FROM_ENTRY_PTR(p_ins, p_chunk_rec, container) \
-	((p_chunk_rec)->metadata_recs + (((p_ins) - (p_chunk_rec)->metadata_recs) % \
+#define BUCKET_PTR_FROM_ENTRY_PTR(p_ent, p_chunk_rec, container) \
+	((p_chunk_rec)->metadata_recs + (((p_ent) - (p_chunk_rec)->metadata_recs) % \
 	memrect_entries_per_layer((p_chunk_rec)->power_of_two_size, (p_chunk_rec)->log_pitch)))
-/* Terminators must have the alloc_site and the flag both unset. */
-#define ENTRY_IS_NULL(p_ins) (!(p_ins)->alloc_site && !(p_ins)->alloc_site_flag)
-
-/* Continuation records have the flag set and a non-user-address (actually the object
- * size) in the alloc_site. */
-#define IS_CONTINUATION_ENTRY(ins) \
-	(!(INSERT_DESCRIBES_OBJECT(ins)) && (ins)->alloc_site_flag)
-#define ENTRY_GET_STORED_OFFSET(ins) ((ins)->un.bits & 0xff)
-#define ENTRY_GET_THISBUCKET_SIZE(ins) (((ins)->un.bits >> 8) == 0 ? 256 : ((ins)->un.bits >> 8))
 
 static
-struct insert *lookup_small_alloc(const void *ptr, 
+struct entry *lookup_small_alloc(const void *ptr, 
 		struct chunk_rec *p_chunk_rec,
 		struct big_allocation *container,
 		void **out_object_start,
 		size_t *out_object_size);
 
-static void unindex_small_alloc_internal_with_ins(void *ptr, struct chunk_rec *p_chunk_rec, struct big_allocation *container,
-	struct insert *p_ins);
+static void unindex_small_alloc_internal_with_ent(void *ptr, struct chunk_rec *p_chunk_rec, struct big_allocation *container,
+	struct entry *p_ent);
 
 static void unindex_small_alloc_internal(void *ptr, struct chunk_rec *p_chunk_rec,
 	struct big_allocation *container);
 
 static 
 void 
-check_bucket_sanity(struct insert *p_bucket, struct chunk_rec *p_chunk_rec, struct big_allocation *container);
+check_bucket_sanity(struct entry *p_bucket, struct chunk_rec *p_chunk_rec, struct big_allocation *container);
 
 #define MAX_PITCH 256 /* Don't support larger than 256-byte pitches, s.t. remainder fits in one byte */
 
@@ -171,7 +207,7 @@ static struct chunk_rec *make_suballocated_chunk(void *chunk_base, size_t chunk_
 	
 	/* The size of a layer is (normally) 
 	 * the number of bytes required to store one metadata entry per average-size unit. */
-	p_chunk_rec->one_layer_nbytes = (sizeof (struct insert)) * (p_chunk_rec->power_of_two_size >> p_chunk_rec->log_pitch);
+	p_chunk_rec->one_layer_nbytes = (sizeof (struct entry)) * (p_chunk_rec->power_of_two_size >> p_chunk_rec->log_pitch);
 	assert(is_power_of_two(p_chunk_rec->one_layer_nbytes));
 	
 	/* For small chunks, we might not fill a page, so resize the pitch so that we do. */
@@ -180,12 +216,12 @@ static struct chunk_rec *make_suballocated_chunk(void *chunk_base, size_t chunk_
 		// force a one-page layer size, and recalculate the pitch
 		p_chunk_rec->one_layer_nbytes = PAGE_SIZE;
 		/* 
-		      one_layer_nbytes == sizeof insert * chunk_size / pitch
+		      one_layer_nbytes == sizeof entry * chunk_size / pitch
 		
-		  =>  pitch            == sizeof insert * chunk_size / one_layer_nbytes
+		  =>  pitch            == sizeof entry * chunk_size / one_layer_nbytes
 		  
 		*/
-		unsigned pitch = ((sizeof (struct insert)) * p_chunk_rec->power_of_two_size) >> LOG_PAGE_SIZE;
+		unsigned pitch = ((sizeof (struct entry)) * p_chunk_rec->power_of_two_size) >> LOG_PAGE_SIZE;
 		assert(is_power_of_two(pitch));
 		p_chunk_rec->log_pitch = integer_log2(pitch);
 		/* Note also that 
@@ -193,7 +229,7 @@ static struct chunk_rec *make_suballocated_chunk(void *chunk_base, size_t chunk_
 		      one_layer_nrecs  == chunk_size / pitch
 		*/
 	}
-	unsigned nbuckets = p_chunk_rec->one_layer_nbytes / sizeof (struct insert);
+	unsigned nbuckets = p_chunk_rec->one_layer_nbytes / sizeof (struct entry);
 	assert(nbuckets < (uintptr_t) MINIMUM_USER_ADDRESS); // see note about size in index logic, below
 	// FIXME: if this fails, increase the pitch until it's true
 	
@@ -201,7 +237,7 @@ static struct chunk_rec *make_suballocated_chunk(void *chunk_base, size_t chunk_
 	 * to go right down to byte-sized allocations.
 	 * 
 	 * It follows that we allocate enough virtual memory for one entry per byte. */
-	unsigned long nbytes = (sizeof (struct insert)) * p_chunk_rec->power_of_two_size;
+	unsigned long nbytes = (sizeof (struct entry)) * p_chunk_rec->power_of_two_size;
 
 	p_chunk_rec->metadata_recs = mmap(NULL, nbytes,
 			PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE, -1, 0);
@@ -247,46 +283,44 @@ static int index_small_alloc_internal(void *ptr, unsigned size_bytes,
 #else
 	char *end_addr = (char*) ptr + size_bytes;
 	
-	/* Recall: modulus is the offset of ptr from the start of the memory range
+	/* Recall: bucket offset is the offset of ptr from the start of the memory range
 	 * covered by its metadata bucket. */
-	unsigned short modulus = memrect_modulus_of_addr(ptr, container->begin, p_chunk_rec->log_pitch);
+	unsigned short bucket_offset = memrect_bucket_offset_of_addr(ptr, container->begin, p_chunk_rec->log_pitch);
 	
 	/* Get the relevant bucket. */
 	unsigned long bucket_num = memrect_nbucket_of(ptr, container->begin, p_chunk_rec->log_pitch);
-	struct insert *p_bucket = p_chunk_rec->metadata_recs + bucket_num;
+	struct entry *p_bucket = p_chunk_rec->metadata_recs + bucket_num;
 	check_bucket_sanity(p_bucket, p_chunk_rec, container);
 
 	/* Now we need to find a free metadata entry to index this allocation at. */
 	/* What's the first layer that's free? */
-	struct insert *p_ins = p_bucket;
+	struct entry *p_ent = p_bucket;
 	unsigned layer_num = 0;
-	while (!ENTRY_IS_NULL(p_ins))
+	while (!ENTRY_IS_NULL(p_ent))
 	{
-		p_ins += ENTRIES_PER_LAYER(p_chunk_rec);
+		p_ent += ENTRIES_PER_LAYER(p_chunk_rec);
 		++layer_num;
 	}
 	// we should never need to go beyond the last layer
 	assert(layer_num < NLAYERS(p_chunk_rec));
-	
-	/* Store the insert. The object start modulus goes in `bits'. */
-	p_ins->alloc_site = (uintptr_t) __current_allocsite;
-	p_ins->alloc_site_flag = 0;
-	
+		
 	/* We also need to represent the object's size somehow. We choose to use 
-	 * continuation entries since the insert doesn't have enough bits. Continuation entries
-	 * have alloc_site_flag == 1 and alloc_site < MINIMUM_USER_ADDRESS, and the "overhang"
-	 * in bits (0 means "full bucket"). 
+	 * continuation entries since the entry doesn't have enough bits.
 	 * The alloc site entries the bucket number in which the object starts. This limits us to
 	 * 4M buckets, so a 32MByte chunk for 8-byte-pitch, etc., which seems
 	 * bearable for the moment. 
 	 */
 	unsigned short thisbucket_size = (memrect_nbucket_of(end_addr, container->begin, p_chunk_rec->log_pitch) == bucket_num) 
 			? size_bytes
-			: (1u << p_chunk_rec->log_pitch) - modulus;
+			: (1u << p_chunk_rec->log_pitch) - bucket_offset;
 	assert(thisbucket_size != 0);
 	assert(thisbucket_size <= (1u << p_chunk_rec->log_pitch));
 	
-	p_ins->un.bits = (thisbucket_size << 8) | modulus;
+	*p_ent = (struct entry) { .regular_initial = {
+		.alloc_site = (unsigned long) __current_allocsite,
+		.bucket_offset = bucket_offset,
+		.thisbucket_size = thisbucket_size
+	} };
 	
 	/* We should be sane already, even though our continuation is not recorded. */
 	check_bucket_sanity(p_bucket, p_chunk_rec, container);
@@ -294,20 +328,15 @@ static int index_small_alloc_internal(void *ptr, unsigned size_bytes,
 	/* If we spill into the next bucket, set the continuation entry */
 	if ((char*)(BUCKET_RANGE_END(p_bucket, p_chunk_rec, container->begin)) < end_addr)
 	{
-		struct insert *p_continuation_bucket = p_bucket + 1;
+		struct entry *p_continuation_bucket = p_bucket + 1;
 		assert(p_continuation_bucket - &p_chunk_rec->metadata_recs[0] < (uintptr_t) MINIMUM_USER_ADDRESS);
 		check_bucket_sanity(p_continuation_bucket, p_chunk_rec, container);
-		struct insert *p_continuation_ins = p_continuation_bucket;
+		struct entry *p_continuation_ent = p_continuation_bucket;
 		/* Find a free slot */
 		unsigned layer_num = 0;
-		while (!ENTRY_IS_NULL(p_continuation_ins))
-		{ p_continuation_ins += ENTRIES_PER_LAYER(p_chunk_rec); ++layer_num; }
+		while (!ENTRY_IS_NULL(p_continuation_ent))
+		{ p_continuation_ent += ENTRIES_PER_LAYER(p_chunk_rec); ++layer_num; }
 		assert(layer_num < NLAYERS(p_chunk_rec));
-		
-		//unsigned short thisbucket_size = (end_addr >= BUCKET_RANGE_BASE(p_bucket + 1, p_chunk_rec))
-		//		? 0
-		//		: (char*) end_addr - (char*) BUCKET_RANGE_BASE(p_bucket, p_chunk_rec);
-		//assert(thisbucket_size < 256);
 		
 		unsigned long size_after_first_bucket = size_bytes - thisbucket_size;
 		assert(size_after_first_bucket != 0);
@@ -317,12 +346,13 @@ static int index_small_alloc_internal(void *ptr, unsigned size_bytes,
 		// install the continuation entry
 		assert(size_bytes > 0);
 		assert(size_bytes < (uintptr_t) MINIMUM_USER_ADDRESS);
-		*p_continuation_ins = (struct insert) {
-			.alloc_site = size_bytes, // NOTE what we're doing here! the object size goes into the alloc_site field
-			.alloc_site_flag = 1,     // ditto
-			.un = { bits: (unsigned short) (size_in_continuation_bucket << 8) }  // ditto: modulus is zero, BUT size is included
+		*p_continuation_ent = (struct entry) {
+			.continuation = {
+				size: size_bytes,
+				thisbucket_size: size_in_continuation_bucket
+			}
 		};
-		assert(IS_CONTINUATION_ENTRY(p_continuation_ins));
+		assert(ENTRY_IS_CONTINUATION(p_continuation_ent));
 		check_bucket_sanity(p_continuation_bucket, p_chunk_rec, container);
 	}
 	
@@ -330,11 +360,11 @@ static int index_small_alloc_internal(void *ptr, unsigned size_bytes,
 	if (p_chunk_rec->biggest_object < size_bytes) p_chunk_rec->biggest_object = size_bytes;
 	
 #ifndef NDEBUG
-	struct insert *p_found_ins1 = lookup_small_alloc(ptr, p_chunk_rec, container, NULL, NULL);
-	assert(p_found_ins1 == p_ins);
-	struct insert *p_found_ins2 = lookup_small_alloc((char*) ptr + size_bytes - 1, 
+	struct entry *p_found_ent1 = lookup_small_alloc(ptr, p_chunk_rec, container, NULL, NULL);
+	assert(p_found_ent1 == p_ent);
+	struct entry *p_found_ent2 = lookup_small_alloc((char*) ptr + size_bytes - 1, 
 		p_chunk_rec, container, NULL, NULL);
-	assert(p_found_ins2 == p_ins);
+	assert(p_found_ent2 == p_ent);
 #endif
 	
 #endif
@@ -345,22 +375,22 @@ static void unindex_all_overlapping(void *unindex_start, void *unindex_end,
 {
 	unsigned long bucket_num = memrect_nbucket_of(unindex_start, container->begin,
 		p_chunk_rec->log_pitch);
-	struct insert *p_bucket = p_chunk_rec->metadata_recs + bucket_num;
+	struct entry *p_bucket = p_chunk_rec->metadata_recs + bucket_num;
 	// 0. handle the case of an object starting [maybe much] earlier
 	// creeping over into this bucket.
 	void *earlier_object_start;
 	size_t earlier_object_size;
-	struct insert *p_old_ins = lookup_small_alloc(unindex_start, p_chunk_rec,
+	struct entry *p_old_ent = lookup_small_alloc(unindex_start, p_chunk_rec,
 		container, &earlier_object_start, &earlier_object_size);
-	if (p_old_ins) 
+	if (p_old_ent) 
 	{
-		unindex_small_alloc_internal_with_ins(earlier_object_start, p_chunk_rec, 
-			container, p_old_ins);
+		unindex_small_alloc_internal_with_ent(earlier_object_start, p_chunk_rec, 
+			container, p_old_ent);
 	}
 	
-	unsigned short modulus = memrect_modulus_of_addr(unindex_start, container->begin, p_chunk_rec->log_pitch);
+	unsigned short bucket_offset = memrect_bucket_offset_of_addr(unindex_start, container->begin, p_chunk_rec->log_pitch);
 	// 1. now any object that overlaps us must start later than us, walk up the buckets
-	for (struct insert *p_search_bucket = p_bucket;
+	for (struct entry *p_search_bucket = p_bucket;
 			// we might find an object overlapping that starts in this bucket if 
 			// -- our bucket range base is not later than the end of our object, and
 			// -- our bucket range end is not earlier than the 
@@ -369,18 +399,18 @@ static void unindex_all_overlapping(void *unindex_start, void *unindex_end,
 			
 			++p_search_bucket)
 	{
-		for (struct insert *i_layer = p_search_bucket; 
+		for (struct entry *i_layer = p_search_bucket; 
 				!ENTRY_IS_NULL(i_layer); 
 				i_layer += ENTRIES_PER_LAYER(p_chunk_rec))
 		{
 			/* Does this object overlap our allocation? */
 			char *this_object_start;
 			char *this_object_end_thisbucket;
-			struct insert *this_object_ins;
+			struct entry *this_object_ent;
 			
 			/* We don't care about continuation entrys; we'll find the 
 			 * start record before any relevant continuation record. */
-			if (IS_CONTINUATION_ENTRY(i_layer))
+			if (ENTRY_IS_CONTINUATION(i_layer))
 			{
 				// FIXME: assert that it doesn't overlap
 				continue;
@@ -393,7 +423,7 @@ static void unindex_all_overlapping(void *unindex_start, void *unindex_end,
 			if (this_object_start < (char*) unindex_end 
 					&& this_object_end_thisbucket > (char*) unindex_start)
 			{
-				unindex_small_alloc_internal_with_ins(this_object_start, p_chunk_rec, 
+				unindex_small_alloc_internal_with_ent(this_object_start, p_chunk_rec, 
 					container, i_layer);
 				/* HACK: this deletes i_layer, so move it back one. */
 				i_layer -= ENTRIES_PER_LAYER(p_chunk_rec);
@@ -470,93 +500,95 @@ int __index_small_alloc(void *ptr, int level, unsigned size_bytes)
 }
 
 static _Bool
-get_start_from_continuation(struct insert *p_ins, struct insert *p_bucket, 
+get_start_from_continuation(struct entry *p_ent, struct entry *p_bucket, 
 		struct chunk_rec *p_chunk_rec, struct big_allocation *container,
-		void **out_object_start, size_t *out_object_size, struct insert **out_object_ins)
+		void **out_object_start, size_t *out_object_size, struct entry **out_object_ent)
 {
 	/* NOTE: don't sanity check buckets in this function, because we might be 
 	 * called from inside check_bucket_sanity(). */
 	
 	// the object starts somewhere in the previous bucket
 	// okay: hop back to the object start
-	struct insert *p_object_start_bucket = p_bucket - 1;
+	struct entry *p_object_start_bucket = p_bucket - 1;
 
-	// walk the object start bucket looking for the *last* object i.e. biggest modulus
-	struct insert *object_ins;
-	struct insert *biggest_modulus_pos = NULL;
-	for (struct insert *i_layer = p_object_start_bucket;
+	// walk the object start bucket looking for the *last* object i.e. biggest bucket offset
+	struct entry *object_ent;
+	struct entry *biggest_bucket_offset_pos = NULL;
+	for (struct entry *i_layer = p_object_start_bucket;
 			!ENTRY_IS_NULL(i_layer);
 			i_layer += ENTRIES_PER_LAYER(p_chunk_rec))
 	{
-		if (IS_CONTINUATION_ENTRY(i_layer)) continue;
-		// the modulus tells us where this object starts in the bucket range
-		unsigned short modulus = p_object_start_bucket->un.bits & 0xff;
-		if (!biggest_modulus_pos || 
-				ENTRY_GET_STORED_OFFSET(i_layer) > ENTRY_GET_STORED_OFFSET(biggest_modulus_pos))
+		if (ENTRY_IS_CONTINUATION(i_layer)) continue;
+		// the offset tells us where this object starts in the bucket range
+		unsigned short bucket_offset = p_object_start_bucket->common.bucket_offset;
+		if (!biggest_bucket_offset_pos || 
+				ENTRY_GET_STORED_OFFSET(i_layer) > ENTRY_GET_STORED_OFFSET(biggest_bucket_offset_pos))
 		{
-			biggest_modulus_pos = i_layer;
+			biggest_bucket_offset_pos = i_layer;
 		}
 	}
 	// we must have seen the last object
-	assert(biggest_modulus_pos);
-	object_ins = biggest_modulus_pos;
+	assert(biggest_bucket_offset_pos);
+	object_ent = biggest_bucket_offset_pos;
 	char *object_start = (char*)(BUCKET_RANGE_BASE(p_object_start_bucket, p_chunk_rec, container->begin)) 
-			+ ENTRY_GET_STORED_OFFSET(biggest_modulus_pos);
-	uintptr_t object_size = p_ins->alloc_site;
-	
+			+ ENTRY_GET_STORED_OFFSET(biggest_bucket_offset_pos);
+	uintptr_t object_size = p_ent->continuation.size;
+
 	if (out_object_start) *out_object_start = object_start;
 	if (out_object_size) *out_object_size = object_size;
-	if (out_object_ins) *out_object_ins = object_ins;
+	if (out_object_ent) *out_object_ent = object_ent;
 	
 	return 1;
 }
 
 static 
 void 
-check_bucket_sanity(struct insert *p_bucket, struct chunk_rec *p_chunk_rec, struct big_allocation *container)
+check_bucket_sanity(struct entry *p_bucket, struct chunk_rec *p_chunk_rec, struct big_allocation *container)
 {
 #ifndef NDEBUG
-	/* Walk the bucket */
 	unsigned layer_num = 0;
-	for (struct insert *i_layer = p_bucket;
+	for (struct entry *i_layer = p_bucket;
 			!ENTRY_IS_NULL(i_layer);
 			i_layer += ENTRIES_PER_LAYER(p_chunk_rec), ++layer_num)
 	{
 		// we should never need to go beyond the last layer
 		assert(layer_num < NLAYERS(p_chunk_rec));
-		
-		unsigned short thisbucket_size = i_layer->un.bits >> 8;
-		unsigned short modulus = i_layer->un.bits & 0xff;
-		
-		assert(modulus < (1u << p_chunk_rec->log_pitch));
-		
-		if (IS_CONTINUATION_ENTRY(i_layer))
+
+		if (ENTRY_IS_CONTINUATION(i_layer))
 		{
+			assert(i_layer->continuation.thisbucket_size != 0);
 			/* Check that the *previous* bucket contains the object start */
 			assert(get_start_from_continuation(i_layer, p_bucket, p_chunk_rec, container,
 					NULL, NULL, NULL));
+		} else {
+			unsigned short bucket_offset = i_layer->common.bucket_offset;
+			unsigned short thisbucket_size = i_layer->common.thisbucket_size;
+
+			assert(bucket_offset < (1u << p_chunk_rec->log_pitch));
+
+			/* Check we don't overlap with anything else in this bucket. */
+			for (struct entry *i_earlier_layer = p_bucket;
+				i_earlier_layer != i_layer;
+				i_earlier_layer += ENTRIES_PER_LAYER(p_chunk_rec))
+			{
+
+				const unsigned our_end = bucket_offset + thisbucket_size;
+
+				if(ENTRY_IS_CONTINUATION(i_earlier_layer))
+				{
+					assert(i_earlier_layer->continuation.thisbucket_size != 0);
+				} else {
+					const unsigned short thisbucket_earlier_size = i_earlier_layer->common.thisbucket_size;
+					const unsigned short earlier_bucket_offset = i_earlier_layer->common.bucket_offset;
+					const unsigned earlier_end = earlier_bucket_offset + thisbucket_earlier_size;
+
+					// conventional overlap
+					assert(!(earlier_end > bucket_offset && earlier_bucket_offset < our_end));
+					assert(!(our_end > earlier_bucket_offset && bucket_offset < earlier_end));
+				}				
+			}
 		}
 		
-		/* Check we don't overlap with anything else in this bucket. */
-		for (struct insert *i_earlier_layer = p_bucket;
-			i_earlier_layer != i_layer;
-			i_earlier_layer += ENTRIES_PER_LAYER(p_chunk_rec))
-		{
-			unsigned short thisbucket_earlier_size = i_earlier_layer->un.bits >> 8;
-			unsigned short earlier_modulus = i_earlier_layer->un.bits & 0xff;
-			
-			// note that either entry might be a continuation entry
-			// ... in which case zero-size means "the whole bucket"
-			assert(!(IS_CONTINUATION_ENTRY(i_earlier_layer) && thisbucket_earlier_size == 0));
-			assert(!(IS_CONTINUATION_ENTRY(i_layer) && thisbucket_size == 0));
-
-			unsigned earlier_end = earlier_modulus + thisbucket_earlier_size;
-			unsigned our_end = modulus + thisbucket_size;
-			
-			// conventional overlap
-			assert(!(earlier_end > modulus && earlier_modulus < our_end));
-			assert(!(our_end > earlier_modulus && modulus < earlier_end));
-		}
 	}
 
 #endif
@@ -571,7 +603,7 @@ static void delete_suballocated_chunk(struct chunk_rec *p_rec)
 	*p_bitmap_word &= ~(1ul<<bit_index);
 
 	/* munmap it. */
-	int ret = munmap(p_rec->metadata_recs, (sizeof (struct insert)) * p_rec->size);
+	int ret = munmap(p_rec->metadata_recs, (sizeof (struct entry)) * p_rec->size);
 	assert(ret == 0);
 	ret = munmap(p_rec->starts_bitmap,
 		sizeof (unsigned long) * (p_rec->real_size / UNSIGNED_LONG_NBITS));
@@ -582,11 +614,13 @@ static void delete_suballocated_chunk(struct chunk_rec *p_rec)
 			
 	/* We might want to restore the previous alloc_site bits in the higher-level 
 	 * chunk. But we assume that's been/being deleted, so we don't bother. */
+#else 
+	abort();
 #endif
 }
 
 static
-struct insert *lookup_small_alloc(const void *ptr,
+struct entry *lookup_small_alloc(const void *ptr,
 		struct chunk_rec *p_chunk_rec,
 		struct big_allocation *container,
 		void **out_object_start,
@@ -599,8 +633,8 @@ struct insert *lookup_small_alloc(const void *ptr,
 	 * If it has itself been sub-allocated, we recurse (FIXME), 
 	 * and if that fails, stick with the result we have. */
 	unsigned start_bucket_num = memrect_nbucket_of((void*) ptr, container->begin, p_chunk_rec->log_pitch);
-	struct insert *p_start_bucket = &p_chunk_rec->metadata_recs[start_bucket_num];
-	struct insert *p_bucket = p_start_bucket;
+	struct entry *p_start_bucket = &p_chunk_rec->metadata_recs[start_bucket_num];
+	struct entry *p_bucket = p_start_bucket;
 	_Bool must_see_continuation = 0; // a bit like seen_object_starting_earlier
 	char *earliest_possible_start = (char*) ptr - p_chunk_rec->biggest_object;
 	do 
@@ -611,9 +645,9 @@ struct insert *lookup_small_alloc(const void *ptr,
 		check_bucket_sanity(p_bucket, p_chunk_rec, container);
 		
 		unsigned layer_num = 0;
-		for (struct insert *p_ins = p_bucket;
-			!ENTRY_IS_NULL(p_ins);
-			p_ins += ENTRIES_PER_LAYER(p_chunk_rec), ++layer_num)
+		for (struct entry *p_ent = p_bucket;
+			!ENTRY_IS_NULL(p_ent);
+			p_ent += ENTRIES_PER_LAYER(p_chunk_rec), ++layer_num)
 		{
 			// we should never need to go beyond the last layer
 			assert(layer_num < NLAYERS(p_chunk_rec));
@@ -623,26 +657,23 @@ struct insert *lookup_small_alloc(const void *ptr,
 			 *
 			 * it's an object start entry (ditto).
 			 */
-			unsigned short object_size_in_this_bucket = p_ins->un.bits >> 8;
-			unsigned short modulus = p_ins->un.bits & 0xff;
 
-			if (IS_CONTINUATION_ENTRY(p_ins))
+			if (ENTRY_IS_CONTINUATION(p_ent))
 			{
 				/* Does this continuation overlap our search address? */
-				assert(modulus == 0); // continuation recs have modulus zero
-				
+			
 				void *object_start;
 				size_t object_size;
-				struct insert *object_ins;
-				_Bool success = get_start_from_continuation(p_ins, p_bucket,
+				struct entry *object_ent;
+				_Bool success = get_start_from_continuation(p_ent, p_bucket,
 						p_chunk_rec, container,
-						&object_start, &object_size, &object_ins);
+						&object_start, &object_size, &object_ent);
 				
 				if ((char*) object_start + object_size > (char*) ptr)
 				{
 					// hit! 
 					if (out_object_start) *out_object_start = object_start;
-					return object_ins;
+					return object_ent;
 				}
 				// else it's a continuation that we don't overlap
 				// -- we can give up 
@@ -651,8 +682,9 @@ struct insert *lookup_small_alloc(const void *ptr,
 			else 
 			{
 				/* It's an object start entry. Does it overlap? */
-				char modulus = p_ins->un.bits & 0xff;
-				char *object_start_addr = thisbucket_base_addr + modulus;
+				unsigned bucket_offset = p_ent->common.bucket_offset;
+				unsigned short object_size_in_this_bucket = p_ent->common.thisbucket_size;
+				char *object_start_addr = thisbucket_base_addr + bucket_offset;
 				void *object_end_addr = object_start_addr + object_size_in_this_bucket;
 
 				if ((char*) object_start_addr <= (char*) ptr && (char*) object_end_addr > (char*) ptr)
@@ -660,7 +692,7 @@ struct insert *lookup_small_alloc(const void *ptr,
 					// hit!
 					if (out_object_start) *out_object_start = object_start_addr;
 					if (out_object_size) *out_object_size = object_size_in_this_bucket;
-					return p_ins;
+					return p_ent;
 				}
 			}
 		} // end for each layer
@@ -674,17 +706,17 @@ fail:
 	return NULL;
 }
 
-static void remove_one_insert(struct insert *p_ins, struct insert *p_bucket, struct chunk_rec *p_chunk_rec)
+static void remove_one_entry(struct entry *p_ent, struct entry *p_bucket, struct chunk_rec *p_chunk_rec)
 {
-	struct insert *replaced_ins = p_ins;
+	struct entry *replaced_ent = p_ent;
 	do
 	{
-		struct insert *p_next_layer = replaced_ins + ENTRIES_PER_LAYER(p_chunk_rec);
-		/* Copy the next layer's insert over ours. */
-		*replaced_ins = *p_next_layer;
+		struct entry *p_next_layer = replaced_ent + ENTRIES_PER_LAYER(p_chunk_rec);
+		/* Copy the next layer's entry over ours. */
+		*replaced_ent = *p_next_layer;
 		/* Point us at the next layer to replace (i.e. if it's not null). */
-		replaced_ins = p_next_layer;
-	} while (!ENTRY_IS_NULL(replaced_ins));
+		replaced_ent = p_next_layer;
+	} while (!ENTRY_IS_NULL(replaced_ent));
 }
 
 
@@ -694,42 +726,42 @@ static void unindex_small_alloc_internal(void *ptr, struct chunk_rec *p_chunk_re
 
 	void *alloc_start;
 	size_t alloc_size;
-	struct insert *p_ins = lookup_small_alloc(ptr, p_chunk_rec, container, &alloc_start, 
+	struct entry *p_ent = lookup_small_alloc(ptr, p_chunk_rec, container, &alloc_start, 
 		&alloc_size);
-	assert(p_ins);
+	assert(p_ent);
 	
-	unindex_small_alloc_internal_with_ins(ptr, p_chunk_rec, container, p_ins);
+	unindex_small_alloc_internal_with_ent(ptr, p_chunk_rec, container, p_ent);
 }
 
-static void unindex_small_alloc_internal_with_ins(void *ptr, struct chunk_rec *p_chunk_rec, struct big_allocation *container,
-	struct insert *p_ins)
+static void unindex_small_alloc_internal_with_ent(void *ptr, struct chunk_rec *p_chunk_rec, struct big_allocation *container,
+	struct entry *p_ent)
 {
-	struct insert *p_bucket = BUCKET_PTR_FROM_ENTRY_PTR(p_ins, p_chunk_rec, container);
+	struct entry *p_bucket = BUCKET_PTR_FROM_ENTRY_PTR(p_ent, p_chunk_rec, container);
 	check_bucket_sanity(p_bucket, p_chunk_rec, container);
 	
-	unsigned short our_modulus = ENTRY_GET_STORED_OFFSET(p_ins);
-	_Bool we_are_biggest_modulus = 1;
-	for (struct insert *i_layer = p_bucket;
-			we_are_biggest_modulus && !ENTRY_IS_NULL(i_layer);
+	unsigned short our_bucket_offset = ENTRY_GET_STORED_OFFSET(p_ent);
+	_Bool we_are_biggest_offset = 1;
+	for (struct entry *i_layer = p_bucket;
+			we_are_biggest_offset && !ENTRY_IS_NULL(i_layer);
 			i_layer += ENTRIES_PER_LAYER(p_chunk_rec))
 	{
-		we_are_biggest_modulus &= (our_modulus >= ENTRY_GET_STORED_OFFSET(i_layer));
+		we_are_biggest_offset &= (our_bucket_offset >= ENTRY_GET_STORED_OFFSET(i_layer));
 	}
 	
-	/* Delete this insert and "shift left" any later in the bucket. */
-	remove_one_insert(p_ins, p_bucket, p_chunk_rec);
+	/* Delete this entry and "shift left" any later in the bucket. */
+	remove_one_entry(p_ent, p_bucket, p_chunk_rec);
 	check_bucket_sanity(p_bucket, p_chunk_rec, container);
 	
-	/* If we were the biggest modulus, delete any continuation entry in the next bucket. */
-	if (we_are_biggest_modulus)
+	/* If we were the biggest offset, delete any continuation entry in the next bucket. */
+	if (we_are_biggest_offset)
 	{
-		for (struct insert *i_layer = p_bucket + 1;
+		for (struct entry *i_layer = p_bucket + 1;
 				!ENTRY_IS_NULL(i_layer);
 				i_layer += ENTRIES_PER_LAYER(p_chunk_rec))
 		{
-			if (IS_CONTINUATION_ENTRY(i_layer))
+			if (ENTRY_IS_CONTINUATION(i_layer))
 			{
-				remove_one_insert(i_layer, p_bucket + 1, p_chunk_rec);
+				remove_one_entry(i_layer, p_bucket + 1, p_chunk_rec);
 				check_bucket_sanity(p_bucket + 1, p_chunk_rec, container);
 				break;
 			}
@@ -766,15 +798,51 @@ static liballocs_err_t get_info(void *obj, struct big_allocation *b,
 		? BIDX(b->parent)
 		 : __lookup_deepest_bigalloc(obj);
 	
-	struct insert *heap_info = lookup_small_alloc(obj, container->suballocator_private,
+	struct entry *p_ent = lookup_small_alloc(obj, container->suballocator_private,
 		container, out_base, out_size);
-	if (!heap_info)
+	if (!p_ent)
 	{
 		++__liballocs_aborted_unindexed_heap;
 		return &__liballocs_err_unindexed_heap_object;
 	}
-	
-	return extract_and_output_alloc_site_and_type(heap_info, out_type, (void**) out_site);
+	struct uniqtype *alloc_uniqtype = NULL;
+	/* Now we have a uniqtype or an allocsite. For long-lived objects 
+	 * the uniqtype will have been installed in the heap header already.
+	 * This is the expected case. */
+	assert(p_ent->common.discr != 0); // null entry -- we should not be passed these
+	assert(p_ent->common.discr >= MINIMUM_USER_ADDRESS); // continuation entry -- ditto
+	if (p_ent->common.discr < (1ull << (ADDR_BITSIZE - 1))) // 'regular initial' entry
+	{
+		void *alloc_site = (void*)(unsigned long) p_ent->regular_initial.alloc_site;
+		if (out_site) *out_site = alloc_site;
+		if (out_type)
+		{
+			struct allocsite_entry *entry = __liballocs_find_allocsite_entry_at(alloc_site);
+			alloc_uniqtype = entry ? entry->uniqtype : NULL;
+			/* Remember the unrecog'd alloc sites we see. */
+			if (!alloc_uniqtype && alloc_site && 
+					!__liballocs_addrlist_contains(&__liballocs_unrecognised_heap_alloc_sites, alloc_site))
+			{
+				__liballocs_addrlist_add(&__liballocs_unrecognised_heap_alloc_sites, alloc_site);
+			}
+			*out_type = alloc_uniqtype;
+		}
+	}
+	else // 'regular with type' entry
+	{
+		assert(0); // currently we never progress to the with_type state
+	}
+	// FIXME: same optimizations as generic_malloc (use thewith_type state, and in
+	// non-debug builds, zero out unrecognised alloc sites after the first failing lookup)
+
+	// if we didn't get an alloc uniqtype, record the abort we abort
+	if (out_type && !alloc_uniqtype) 
+	{
+		++__liballocs_aborted_unrecognised_allocsite;
+		return &__liballocs_err_unrecognised_alloc_site;;
+	}
+	/* return success */
+	return NULL;
 }
 
 struct allocator __generic_small_allocator = {

--- a/src/allocators/generic_small.c
+++ b/src/allocators/generic_small.c
@@ -556,7 +556,7 @@ check_bucket_sanity(struct entry *p_bucket, struct chunk_rec *p_chunk_rec, struc
 
 		if (ENTRY_IS_CONTINUATION(i_layer))
 		{
-			assert(i_layer->continuation.thisbucket_size != 0);
+			// assert(i_layer->continuation.thisbucket_size != 0); // FIXME: size 0 means 256, this assert won't work. But there could be a better one here
 			/* Check that the *previous* bucket contains the object start */
 			assert(get_start_from_continuation(i_layer, p_bucket, p_chunk_rec, container,
 					NULL, NULL, NULL));


### PR DESCRIPTION
This PR reworks the generic_small allocator so that it doesn't use the insert struct from malloc_meta anymore, but is more self-contained.

This is a prerequisite to the rework of the malloc_meta insert struct (https://github.com/stephenrkell/liballocs/issues/110)

Needed to resolve https://github.com/stephenrkell/liballocs/issues/58