### PR TITLE
fix: enforce dwarf4 in test and liballocs compilation

### DIFF
--- a/include/generic_malloc_index.h
+++ b/include/generic_malloc_index.h
@@ -53,6 +53,13 @@ extern int __currently_allocating;
 //void __free_arena_bitmap_and_info(void *info);
 #define __liballocs_free_arena_bitmap_and_info __free_arena_bitmap_and_info
 #define __liballocs_extract_and_output_alloc_site_and_type extract_and_output_alloc_site_and_type
+#else
+/* When building stubs for execution outside the liballocs DSO, e.g.
+ * for an in-exe malloc, the stubs will call out cross-DSO to the "public"
+ * symbol of the liballocs private malloc. */
+liballocs_err_t __liballocs_extract_and_output_alloc_site_and_type(struct insert *p_ins, 
+	struct uniqtype **out_type,
+	void **out_site);
 #endif
 
 static inline

--- a/tests/anon-aliases/mk.inc
+++ b/tests/anon-aliases/mk.inc
@@ -3,3 +3,8 @@ anon-aliases: lib1.o lib2.o lib3.o
 lib1.o: CC := cc
 lib2.o: CC := cc
 lib3.o: CC := cc
+
+# HACK: Force DWARF 4 until v5 is not supported (https://github.com/stephenrkell/liballocs/issues/77)
+lib1.o: CFLAGS += -gdwarf-4
+lib2.o: CFLAGS += -gdwarf-4
+lib3.o: CFLAGS += -gdwarf-4

--- a/tests/lib-test/mk.inc
+++ b/tests/lib-test/mk.inc
@@ -2,7 +2,7 @@ THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
 # lib-test is a plain old C program, not allocscc'd, and it
 # dlopens liballocs (test build) to run its self-test constructors.
 export CC := cc
-export CFLAGS := -fPIC -O0 -g3 -DTEST
+export CFLAGS := -fPIC -O0 -g3 -DTEST -gdwarf-4 # HACK: Force DWARF 4 until v5 is not supported (https://github.com/stephenrkell/liballocs/issues/77)
 srcroot := $(realpath $(dir $(realpath $(THIS_MAKEFILE)))../..)
 # One exception: we must avoid the ld.so  hole, so use allocsld for that.
 export LDFLAGS := -Wl,--dynamic-linker,$(srcroot)/allocsld/allocsld.so

--- a/tools/allocscompilerwrapper.py
+++ b/tools/allocscompilerwrapper.py
@@ -80,10 +80,12 @@ class AllocsCompilerWrapper(CompilerWrapper):
     def getDummyWeakLinkArgs(self, outputIsDynamic, outputIsExecutable):
         if outputIsDynamic and outputIsExecutable:
             return [ "-Wl,--push-state", "-Wl,--no-as-needed", \
-                    self.getLinkPath() + "/lib" + self.getLibNameStem() + "_" + self.getDummyWeakObjectNameStem() + ".so", \
+                     "-l" + self.getLibNameStem() + "_" + self.getDummyWeakObjectNameStem(), \
                     "-Wl,--pop-state" ]
         elif outputIsDynamic and not outputIsExecutable:
-            return [self.getLinkPath() + "/lib" + self.getLibNameStem() + "_" + self.getDummyWeakObjectNameStem() + ".o"]
+            return [ "-Wl,--push-state", "-Wl,--no-as-needed", \
+                     "-l" + self.getLibNameStem() + "_" + self.getDummyWeakObjectNameStem(), \
+                    "-Wl,--pop-state" ]
         else:
             return []
     


### PR DESCRIPTION


After merging https://github.com/stephenrkell/cil/pull/17 and this PR, and updating `libdlbind`, `liballocs` builds and tests pass on
`gcc version 15.2.0 (Ubuntu 15.2.0-4ubuntu4) `